### PR TITLE
Исправления .gitignore: добавлен общий шаблон для __pycache__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,12 @@
 /venv
 /venv2
-/__pycache__
 /.idea
-/FunPayAPI/__pycache__
 /logs
 /storage
 /configs
 /plugins
 /build
 /dist
+__pycache__
 test.py
 backup.zip


### PR DESCRIPTION
Фикс `.gitignore`, т.к. `__pycache__` создается не только в `/` и `/FunPayAPI`