### PR TITLE
fix(raise_lots): обработка отсутствующего поля «wait» в ответе FunPay

### DIFF
--- a/FunPayAPI/account.py
+++ b/FunPayAPI/account.py
@@ -1209,7 +1209,7 @@ class Account:
         logger.debug(f"Ответ FunPay (поднятие категорий): {json_response}.")  # locale
         wait_time = json_response.get("wait")
         if not json_response.get("error") and not json_response.get("url"):
-            return wait_time
+            return wait_time if wait_time is not None else 7200
         elif json_response.get("url"):
             raise exceptions.RaiseError(response, category, json_response.get("url"), wait_time or 7200)
         elif json_response.get("error") and json_response.get("msg") and \

--- a/Utils/cardinal_tools.py
+++ b/Utils/cardinal_tools.py
@@ -311,6 +311,7 @@ def time_to_str(time_: int):
 
     :return: строку-время.
     """
+    time_ = int(time_ or 0)
     days = time_ // 86400
     hours = (time_ - days * 86400) // 3600
     minutes = (time_ - days * 86400 - hours * 3600) // 60

--- a/cardinal.py
+++ b/cardinal.py
@@ -330,7 +330,7 @@ class Cardinal(object):
                 last_time = self.raised_time.get(subcat.category.id)
                 self.raised_time[subcat.category.id] = new_time = int(time.time())  # locale
                 time_delta = "" if not last_time else f" Последнее поднятие: {cardinal_tools.time_to_str(new_time - last_time)} назад."
-                error_text = f"Подождите {cardinal_tools.time_to_str(wait_time)}."
+                error_text = f"Подождите {cardinal_tools.time_to_str(wait_time if wait_time is not None else 7200)}."
             except FunPayAPI.exceptions.RaiseError as e:
                 if e.error_message is not None:
                     error_text = e.error_message


### PR DESCRIPTION
Регрессия после рефактора `raise_lots`.

### Проблема
`Account.raise_lots()` возвращал `json_response.get("wait")` напрямую. Когда успешный ответ FunPay не содержит поле `wait`, возвращается `None`, который дальше попадает в:
- `time_to_str(None)` → `None // 86400` → `TypeError`;
- `time.time() + None` → `TypeError`.

В итоге **успешное** поднятие лотов ловится общим `except Exception`, логируется как «непредвиденная ошибка» и добавляется лишний `sleep 10`.

### Решение
- `account.raise_lots`: фолбэк на `7200`, когда поле `wait` отсутствует (соответствует задекларированному типу возврата `int`).
- `cardinal.raise_lots`: защита форматирования `error_text`.
- `time_to_str`: приведение `None` к `0`, чтобы любой вызывающий код (включая плагины) был защищён.

🤖 Generated with [Claude Code](https://claude.com/claude-code)