### PR TITLE
fix(ПУ): остановка create_gf после ошибки создания товарного файла

### DIFF
--- a/tg_bot/auto_delivery_cp.py
+++ b/tg_bot/auto_delivery_cp.py
@@ -188,9 +188,10 @@ $product""")  # todo
         try:
             with open(f"storage/products/{file_name}", "w", encoding="utf-8"):
                 pass
-        except:
+        except Exception:
             logger.debug("TRACEBACK", exc_info=True)
             bot.reply_to(m, _("gf_creation_err", file_name), reply_markup=error_keyboard)
+            return
 
         file_index = os.listdir("storage/products").index(file_name)
         offset = file_index - 4 if file_index - 4 > 0 else 0


### PR DESCRIPTION
### Проблема
При ошибке создания товарного файла `create_gf` логировал ошибку и отвечал пользователю, но не делал `return`. Выполнение продолжалось до `os.listdir(...).index(file_name)` для несуществующего файла → `ValueError`, который проглатывался общим обработчиком сообщений, оставляя пользователя без внятного ответа.

### Решение
Добавлен недостающий `return`, голый `except` сужен до `except Exception`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)