### PR TITLE
refactor(выдача): единый источник истины c.autodelivery_enabled

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -628,7 +628,7 @@ def deliver_product_handler(c: Cardinal, e: NewOrderEvent, *args) -> None:
     """
     Обертка для deliver_product(), обрабатывающая ошибки.
     """
-    if not c.MAIN_CFG["FunPay"].getboolean("autoDelivery"):
+    if not c.autodelivery_enabled:
         return
     if e.order.buyer_username in c.blacklist and c.bl_delivery_enabled:
         logger.info(f"Пользователь {e.order.buyer_username} находится в ЧС и включена блокировка автовыдачи. "


### PR DESCRIPTION
### Проблема
`deliver_product_handler` читал `MAIN_CFG["FunPay"]["autoDelivery"]` напрямую, тогда как остальная кодовая база использует свойство `c.autodelivery_enabled`. Два источника истины для одного флага — риск рассинхрона при будущих изменениях.

### Решение
Приведено к свойству `c.autodelivery_enabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)