### PR TITLE
chore(deps): обновление requests до >=2.32.2 (CVE-2023-32681, CVE-2024-35195)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 psutil>=5.9.4
 beautifulsoup4>=4.11.1
 colorama>=0.4.6
-requests==2.28.1
+requests>=2.32.2
 pytelegrambotapi==4.15.2
 pillow>=9.3.0
 requests_toolbelt==0.10.1


### PR DESCRIPTION
### Проблема
`requests` был закреплён на версии 2.28.1 (2022 г.), уязвимой к:
- **CVE-2023-32681**: утечка заголовка `Proxy-Authorization` на целевой хост при редиректе HTTPS→HTTP (исправлено в 2.31.0) — напрямую релевантно, т.к. бот поддерживает авторизованные прокси.
- **CVE-2024-35195**: сессия с отключённой проверкой сертификата продолжала игнорировать проверку и в последующих запросах (исправлено в 2.32.0).

### Решение
`requests>=2.32.2`. Совместимо с `requests_toolbelt 0.10.1` и `pyTelegramBotAPI`.

`pytelegrambotapi` намеренно не обновлялся — мажорный апгрейд может затронуть API бота, это отдельная задача.

🤖 Generated with [Claude Code](https://claude.com/claude-code)