### PR TITLE
Фикс зависимости urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests_toolbelt==0.10.1
 lxml>=5.3.0
 bcrypt>=4.2.0
 pysocks>=1.7.1
+urllib3<2


### PR DESCRIPTION
Очень простой фикс ошибки
ImportError: cannot import name 'appengine' from 'urllib3.contrib' (/home/darky/temp/new/venv/lib/python3.14/site-packages/urllib3/contrib/__init__.py)
Из-за мажорного апдейта urllib3. В кардинале используется старая версия, а загружается новая несовместимая